### PR TITLE
Bump concourse size

### DIFF
--- a/terraform/concourse/variables.tf
+++ b/terraform/concourse/variables.tf
@@ -49,7 +49,7 @@ variable "data_disk" {
 
 variable "vmsize" {
   description = "VM type to be used for concourse"
-  default     = "e2-standard-2"
+  default     = "e2-standard-4"
 }
 
 # Provision options


### PR DESCRIPTION
Use 4 core/16G instance. This is because acceptance tests currently take ca 1h vs half that on old cfi concourse.