### PR TITLE
Scale concourse disk performance, bump concourse version

### DIFF
--- a/docker-versions.sh
+++ b/docker-versions.sh
@@ -5,4 +5,4 @@
 export nginx_version="1.27.1"
 export certbot_version="v2.11.0"
 export postgres_version="17"
-export concourse_version="7.11.2-ubuntu-20240811"
+export concourse_version="7.12.0"

--- a/terraform/concourse/concourse.tf
+++ b/terraform/concourse/concourse.tf
@@ -25,7 +25,7 @@ resource "google_dns_record_set" "concourse" {
 
 resource "google_compute_disk" "concourse_volume" {
   name = var.data_disk
-  type = "pd-standard"
+  type = var.disk_type
   size = var.disk_size
   zone = var.zone
 }

--- a/terraform/concourse/concourse.tf
+++ b/terraform/concourse/concourse.tf
@@ -68,7 +68,7 @@ resource "google_compute_firewall" "https" {
 
 resource "google_compute_instance" "concourse" {
   name                      = var.hostname
-  machine_type              = var.vmsize
+  machine_type              = var.vm_size
   zone                      = var.zone
   allow_stopping_for_update = true
 

--- a/terraform/concourse/variables.tf
+++ b/terraform/concourse/variables.tf
@@ -39,7 +39,12 @@ variable "hostname" {
 # VM parameters
 variable "disk_size" {
   description = "size in GB for concourse volume"
-  default     = 600
+  default     = 200
+}
+
+variable "disk_type" {
+  description = "disk type for concourse volume"
+  default     = "pd-balanced"
 }
 
 variable "data_disk" {

--- a/terraform/concourse/variables.tf
+++ b/terraform/concourse/variables.tf
@@ -43,11 +43,11 @@ variable "disk_size" {
 }
 
 variable "data_disk" {
-  description = "Additional disk to hold data"
+  description = "device name for concourse volume"
   default     = "sdb"
 }
 
-variable "vmsize" {
+variable "vm_size" {
   description = "VM type to be used for concourse"
   default     = "t2d-standard-4"
 }


### PR DESCRIPTION
Use pd-balanced disk type for better performance. This should further improve acceptance tests runtime, where bosh spends time writing stemcells.

Bump concourse to 7.12.0

Minor code and comments cleanup.